### PR TITLE
add `trim` method to `match line`

### DIFF
--- a/crates/steel-repl/src/repl.rs
+++ b/crates/steel-repl/src/repl.rs
@@ -258,7 +258,7 @@ pub fn repl_base(mut vm: Engine) -> std::io::Result<()> {
             Ok(line) => {
                 rl.add_history_entry(line.as_str()).ok();
                 previous_line_cancelled = false;
-                match line.as_str() {
+                match line.as_str().trim() {
                     ":q" | ":quit" => return Ok(()),
                     ":time" => {
                         print_time = !print_time;


### PR DESCRIPTION
i use stenotypy and text expansion a lot, which adds a space at the end of words.  i hope this pr can be accepted so that i don't have to the delete trailing space every time i enter a command, i.e. `:time ` and `:help `